### PR TITLE
Fixed: User can redefine his email to an email attached to another user

### DIFF
--- a/flowstock_app/templates/flowstock/conta.html
+++ b/flowstock_app/templates/flowstock/conta.html
@@ -52,6 +52,35 @@
         </div>
 
         <div class="bg-secondary bg-opacity-10 border border-secondary border-opacity-25 rounded p-3 mb-3">
+
+			{% if messages %}
+				{% for message in messages %}
+					{% if 'redefining_email' in message.tags %}
+						
+						{% if 'error' in message.tags %}
+							{% with 'danger' as message_class %}
+								<div class="alert alert-{{ message_class }} alert-dismissible show mb-3 d-flex align-items-center justify-content-between p-2" role="alert">
+									<div class="ms-2">{{ message }}</div>
+									<button type="button" class="bg-transparent border-0 p-0 m-0 d-flex align-items-center me-2" data-bs-dismiss="alert" aria-label="Fechar">
+										<i class="bi bi-x-lg fs-5"></i>
+									</button>
+								</div>
+							{% endwith %}
+						{% else %}
+							{% with 'success' as message_class %}
+								<div class="alert alert-{{ message_class }} alert-dismissible show mb-3 d-flex align-items-center justify-content-between p-2" role="alert">
+									<div class="ms-2">{{ message }}</div>
+									<button type="button" class="bg-transparent border-0 p-0 m-0 d-flex align-items-center me-2" data-bs-dismiss="alert" aria-label="Fechar">
+										<i class="bi bi-x-lg fs-5"></i>
+									</button>
+								</div>
+							{% endwith %}
+						{% endif %}
+
+					{% endif %}
+				{% endfor %}
+			{% endif %}
+
             <div id="email-view">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>

--- a/flowstock_app/views.py
+++ b/flowstock_app/views.py
@@ -90,12 +90,16 @@ def account_detail(request):
 				messages.error(request, 'O nome não pode estar vazio')
 				
 		elif field == 'email':
-			if new_value and len(new_value) > 0:
-				request.user.email = new_value
-				request.user.save()
-				messages.success(request, 'E-mail atualizado com sucesso!')
+			if not new_value or not new_value.strip():
+				messages.error(request, 'O e-mail não pode estar vazio', extra_tags='redefining_email')
+			elif new_value.strip() == request.user.email:
+				messages.error(request, 'Digite um email diferente do atual', extra_tags='redefining_email')
+			elif User.objects.exclude(pk=request.user.pk).filter(email=new_value.strip()).exists():
+				messages.error(request, 'Este e-mail já está em uso por outra conta', extra_tags='redefining_email')
 			else:
-				messages.error(request, 'O e-mail não pode estar vazio')
+				request.user.email = new_value.strip()
+				request.user.save()
+				messages.success(request, 'E-mail atualizado com sucesso!', extra_tags='redefining_email')
 			
 		elif field == 'password':
 			if new_value and len(new_value) >= 8:


### PR DESCRIPTION
Before this modification, any user could redefine his email to an email attached to another user, causing conflicts in the database. Now, when they try to redefine their email, it's checked if the email is already used from any user.