### PR TITLE
Fix: User can redefine their name to a name already used

### DIFF
--- a/flowstock_app/templates/flowstock/conta.html
+++ b/flowstock_app/templates/flowstock/conta.html
@@ -21,6 +21,35 @@
         </div>
 
         <div class="bg-secondary bg-opacity-10 border border-secondary border-opacity-25 rounded p-3 mb-3">
+
+			{% if messages %}
+				{% for message in messages %}
+					{% if 'redefining_name' in message.tags %}
+						
+						{% if 'error' in message.tags %}
+							{% with 'danger' as message_class %}
+								<div class="alert alert-{{ message_class }} alert-dismissible show mb-3 d-flex align-items-center justify-content-between p-2" role="alert">
+									<div class="ms-2">{{ message }}</div>
+									<button type="button" class="bg-transparent border-0 p-0 m-0 d-flex align-items-center me-2" data-bs-dismiss="alert" aria-label="Fechar">
+										<i class="bi bi-x-lg fs-5"></i>
+									</button>
+								</div>
+							{% endwith %}
+						{% else %}
+							{% with 'success' as message_class %}
+								<div class="alert alert-{{ message_class }} alert-dismissible show mb-3 d-flex align-items-center justify-content-between p-2" role="alert">
+									<div class="ms-2">{{ message }}</div>
+									<button type="button" class="bg-transparent border-0 p-0 m-0 d-flex align-items-center me-2" data-bs-dismiss="alert" aria-label="Fechar">
+										<i class="bi bi-x-lg fs-5"></i>
+									</button>
+								</div>
+							{% endwith %}
+						{% endif %}
+
+					{% endif %}
+				{% endfor %}
+			{% endif %}
+
             <div id="name-view">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>

--- a/flowstock_app/views.py
+++ b/flowstock_app/views.py
@@ -130,13 +130,17 @@ def account_detail(request):
 		new_value = request.POST.get('new_value')
         
 		if field == 'name':
-			if new_value and len(new_value) > 0:
-				request.user.username = new_value
-				request.user.save()
-				messages.success(request, 'Nome atualizado com sucesso!')
+			if not new_value or not new_value.strip():
+				messages.error(request, 'O nome não pode estar vazio', extra_tags='redefining_name')
+			elif new_value.strip() == request.user.username:
+				messages.error(request, 'Digite um nome diferente do atual', extra_tags='redefining_name')
+			elif User.objects.exclude(pk=request.user.pk).filter(username=new_value.strip()).exists():
+				messages.error(request, 'Este nome já está em uso por outro usuário', extra_tags='redefining_name')
 			else:
-				messages.error(request, 'O nome não pode estar vazio')
-				
+				request.user.username = new_value.strip()
+				request.user.save()
+				messages.success(request, 'Nome atualizado com sucesso!', extra_tags='redefining_name')
+       
 		elif field == 'email':
 			if not new_value or not new_value.strip():
 				messages.error(request, 'O e-mail não pode estar vazio', extra_tags='redefining_email')


### PR DESCRIPTION
## Commit Changes

This modification checks, when user is trying to redefine their name, if the name is already been used from another user. FlowStock could use username to login, so if two users have the same name that will conflict on database.